### PR TITLE
Add Dependabot minimum package age

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,16 +5,28 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+  cooldown:
+    default-days: 5
+    semver-patch-days: 5
+    semver-minor-days: 10
+    semver-major-days: 15
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+  cooldown:
+    default-days: 5
 - package-ecosystem: npm
   directory: "/"
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+  cooldown:
+    default-days: 5
+    semver-patch-days: 5
+    semver-minor-days: 10
+    semver-major-days: 15
   groups:
     babel:
       patterns:


### PR DESCRIPTION
Delay Dependabot updates so new releases are not proposed immediately after publication, reducing exposure to supply chain attacks during the first few days after release.

Use semver-specific cooldowns for Bundler and npm updates, with a five-day fallback for GitHub Actions where per-update values are not available.