### PR TITLE
Mitigate supply-chain attacks with bundle cooldown

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-source 'https://rubygems.org'
+source 'https://rubygems.org', cooldown: 5
 
 gem 'rails', '8.1.3'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,7 +85,7 @@ GEM
     bcrypt_pbkdf (1.1.2)
     bigdecimal (4.1.2)
     bindex (0.8.1)
-    bootsnap (1.24.5)
+    bootsnap (1.24.6)
       msgpack (~> 1.2)
     brakeman (8.0.4)
       racc
@@ -174,7 +174,7 @@ GEM
     jbuilder (2.15.1)
       actionview (>= 7.0.0)
       activesupport (>= 7.0.0)
-    json (2.19.7)
+    json (2.19.8)
     kamal (2.11.0)
       activesupport (>= 7.0)
       base64 (~> 0.2)
@@ -260,7 +260,7 @@ GEM
       pry (>= 0.13, < 0.17)
     pry-rails (0.3.11)
       pry (>= 0.13.0)
-    psych (5.3.1)
+    psych (5.4.0)
       date
       stringio
     public_suffix (7.0.5)
@@ -516,4 +516,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-  4.0.12
+  4.0.13


### PR DESCRIPTION
Introduces the new time-based 'cooldown' filter shipped in Bundler  4.0.13. Most supply-chain attacks exploit a tiny window immediately  after a gem version is published. This feature prevents Bundler from  resolving to any gem version until it has been public for a minimum  number of days, allowing time for community vetting.

Ref: https://blog.rubygems.org/2026/06/03/cooldown-let-new-gems-be-vetted.html

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated gem dependency source configuration to include a cooldown period for package fetches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->